### PR TITLE
Pass componentRestrictions to autocompleteService

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Material-ui is required:
 * types: Array, ```
 The types of predictions to be returned. Four types are supported: 'establishment' for businesses, 'geocode' for addresses, '(regions)' for administrative regions and '(cities)' for localities. If nothing is specified, all types are returned.```, default ```undefined```
 
+* restrictions: Array|String, ```[ 'fr', 'gb'] | 'gb'```
+Restricts predictions to the specified country (ISO 3166-1 Alpha-2 country code, case insensitive). E.g., us, br, au. You can provide a single one, or an array of up to 5 country code strings. See [ComponentRestrictions](https://developers.google.com/maps/documentation/javascript/reference#ComponentRestrictions)
+
 ## Development
 
 * `npm run build` - produces production version

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Material-ui is required:
 * types: Array, ```
 The types of predictions to be returned. Four types are supported: 'establishment' for businesses, 'geocode' for addresses, '(regions)' for administrative regions and '(cities)' for localities. If nothing is specified, all types are returned.```, default ```undefined```
 
-* restrictions: Array|String, ```[ 'fr', 'gb'] | 'gb'```
+* restrictions: ```country:  Array|String```, ```{ country: [ 'fr', 'gb'] | 'gb' }```
 Restricts predictions to the specified country (ISO 3166-1 Alpha-2 country code, case insensitive). E.g., us, br, au. You can provide a single one, or an array of up to 5 country code strings. See [ComponentRestrictions](https://developers.google.com/maps/documentation/javascript/reference#ComponentRestrictions)
 
 ## Development

--- a/src/GooglePlaceAutocomplete.js
+++ b/src/GooglePlaceAutocomplete.js
@@ -62,6 +62,10 @@ class GooglePlaceAutocomplete extends React.Component {
       bounds: this.getBounds()
     };
 
+    if(this.props.restrictions) {
+      request.componentRestrictions = { country: this.props.restrictions };
+    }
+
     this.autocompleteService.getPlacePredictions(request, data => this.updateDatasource(data));
   }
 
@@ -80,7 +84,9 @@ class GooglePlaceAutocomplete extends React.Component {
   }
 
   render() {
-    const {location, radius, bounds, types, ...autoCompleteProps} = this.props; // eslint-disable-line no-unused-vars
+    const {
+      location, radius, bounds, types, restrictions, ...autoCompleteProps // eslint-disable-line no-unused-vars
+    } = this.props;
 
     return (
       <AutoComplete
@@ -103,7 +109,11 @@ GooglePlaceAutocomplete.propTypes = {
   onChange: PropTypes.func.isRequired,
   getRef: PropTypes.func,
   types: PropTypes.arrayOf(PropTypes.string),
-  bounds: PropTypes.object
+  bounds: PropTypes.object,
+  restrictions: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ])
 };
 
 GooglePlaceAutocomplete.defaultProps = {

--- a/src/GooglePlaceAutocomplete.js
+++ b/src/GooglePlaceAutocomplete.js
@@ -22,11 +22,11 @@ class GooglePlaceAutocomplete extends React.Component {
   }
 
   updateDatasource(data) {
-    if(!data || !data.length) {
+    if (!data || !data.length) {
       return false;
     }
 
-    if(this.state.data) {
+    if (this.state.data) {
       this.previousData = { ...this.state.data };
     }
     this.setState({
@@ -36,11 +36,11 @@ class GooglePlaceAutocomplete extends React.Component {
   }
 
   getBounds() {
-    if(!this.props.bounds || (!this.props.bounds.ne && !this.props.bounds.south)) {
+    if (!this.props.bounds || (!this.props.bounds.ne && !this.props.bounds.south)) {
       return undefined;
     }
 
-    if(this.props.bounds.ne && this.props.bounds.sw) {
+    if (this.props.bounds.ne && this.props.bounds.sw) {
       return new google.maps.LatLngBounds(this.props.bounds.sw, this.props.bounds.ne);
     }
 
@@ -62,8 +62,8 @@ class GooglePlaceAutocomplete extends React.Component {
       bounds: this.getBounds()
     };
 
-    if(this.props.restrictions) {
-      request.componentRestrictions = { country: this.props.restrictions };
+    if (this.props.restrictions) {
+      request.componentRestrictions = { ...this.props.restrictions };
     }
 
     this.autocompleteService.getPlacePredictions(request, data => this.updateDatasource(data));
@@ -71,7 +71,7 @@ class GooglePlaceAutocomplete extends React.Component {
 
   onNewRequest(searchText, index) {
     // The index in dataSource of the list item selected, or -1 if enter is pressed in the TextField
-    if(index === -1) {
+    if (index === -1) {
       return false;
     }
     const data = this.previousData || this.state.data;
@@ -110,10 +110,12 @@ GooglePlaceAutocomplete.propTypes = {
   getRef: PropTypes.func,
   types: PropTypes.arrayOf(PropTypes.string),
   bounds: PropTypes.object,
-  restrictions: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string)
-  ])
+  restrictions: PropTypes.shape({
+    country: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
+    ])
+  })
 };
 
 GooglePlaceAutocomplete.defaultProps = {

--- a/src/GooglePlaceAutocomplete.js
+++ b/src/GooglePlaceAutocomplete.js
@@ -15,7 +15,7 @@ class GooglePlaceAutocomplete extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if(this.props.searchText !== nextProps.searchText) {
+    if (this.props.searchText !== nextProps.searchText) {
       this.onUpdateInput(nextProps.searchText, this.state.dataSource);
       this.onInputChange(nextProps.searchText);
     }

--- a/test/GooglePlaceAutocomplete.spec.js
+++ b/test/GooglePlaceAutocomplete.spec.js
@@ -57,7 +57,7 @@ describe('<GooglePlaceAutocomplete />', () => {
                             onNewRequest={onNewRequest}
                             onChange={onChange}
                             searchText=""
-                            restrictions={['France']}
+                            restrictions={{ country: ['France'] }}
                             name={'location'}
                           />);
 
@@ -65,6 +65,7 @@ describe('<GooglePlaceAutocomplete />', () => {
 
     expect(AutocompleteService.prototype.getPlacePredictions.calledOnce).to.be.true;
     expect(AutocompleteService.prototype.getPlacePredictions.args[0][0]).to.have.property('componentRestrictions');
+    expect(AutocompleteService.prototype.getPlacePredictions.args[0][0].componentRestrictions).to.have.property('country').that.includes('France');
 
     AutocompleteService.prototype.getPlacePredictions.restore();
   });

--- a/test/GooglePlaceAutocomplete.spec.js
+++ b/test/GooglePlaceAutocomplete.spec.js
@@ -9,31 +9,30 @@ import AutocompleteService from './MockAutoCompleteService';
 import GooglePlaceAutocomplete from '../src';
 
 describe('<GooglePlaceAutocomplete />', () => {
-  before(function() {
+  before(function () {
     global.google = {
       maps: {
-    		LatLng: function(lat, lng) {
-    			return {
-    				latitude: parseFloat(lat),
-    				longitude: parseFloat(lng),
+        LatLng: function (lat, lng) {
+          return {
+            latitude: parseFloat(lat),
+            longitude: parseFloat(lng),
 
-    				lat: function() { return this.latitude; },
-    				lng: function() { return this.longitude; }
-    			};
-    		},
-    		LatLngBounds: function(ne, sw) {
-    			return {
-    				getSouthWest: function() { return sw; },
-    				getNorthEast: function() { return ne; }
-    			};
-    		},
+            lat: function () { return this.latitude; },
+            lng: function () { return this.longitude; }
+          };
+        },
+        LatLngBounds: function (ne, sw) {
+          return {
+            getSouthWest: function () { return sw; },
+            getNorthEast: function () { return ne; }
+          };
+        },
         places: {
           AutocompleteService
         }
-  		}
-    }
-	});
-
+      }
+    };
+  });
 
   it('Render GooglePlaceAutocomplete', () => {
 

--- a/test/GooglePlaceAutocomplete.spec.js
+++ b/test/GooglePlaceAutocomplete.spec.js
@@ -48,4 +48,25 @@ describe('<GooglePlaceAutocomplete />', () => {
                           />);
   });
 
+  it('Accepts country restrictions', () => {
+    sinon.spy(AutocompleteService.prototype, 'getPlacePredictions');
+    const onNewRequest = sinon.spy();
+
+    const onChange = sinon.spy();
+
+    let wrapper = shallow(<GooglePlaceAutocomplete
+                            onNewRequest={onNewRequest}
+                            onChange={onChange}
+                            searchText=""
+                            restrictions={['France']}
+                            name={'location'}
+                          />);
+
+    wrapper.setProps({ searchText: 'test' });
+
+    expect(AutocompleteService.prototype.getPlacePredictions.calledOnce).to.be.true;
+    expect(AutocompleteService.prototype.getPlacePredictions.args[0][0]).to.have.property('componentRestrictions');
+
+    AutocompleteService.prototype.getPlacePredictions.restore();
+  });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,7 +37,7 @@ var config = {
       },
       {
         test: /(\.jsx|\.js)$/,
-        use: "eslint-loader",
+        use: 'eslint-loader',
         exclude: /node_modules/
       }
     ]


### PR DESCRIPTION
Hi, sometimes it is useful to use ComponentRestrictions to restrict the place predictions API to certain countries.  This PR will allow [ComponentRestrictions](https://developers.google.com/maps/documentation/javascript/reference#ComponentRestrictions) to be passed through props on the component.

I also noticed there were a few inconsistencies with the linting etc and have included those as part of this PR in a seperate commit as they are only small, just let me know if you would like a seperate PR for those.